### PR TITLE
feat: Set the `duckdb.materialize_message` option on load only if not previously specified

### DIFF
--- a/R/duckplyr-package.R
+++ b/R/duckplyr-package.R
@@ -543,7 +543,7 @@ tidyselect::where
 dplyr_mode <- FALSE
 
 on_load({
-  if (!identical(Sys.getenv("TESTTHAT"), "true")) {
+  if (!identical(Sys.getenv("TESTTHAT"), "true") & is.null(getOption("duckdb.materialize_message"))) {
     options(duckdb.materialize_message = TRUE)
   }
 })

--- a/R/duckplyr-package.R
+++ b/R/duckplyr-package.R
@@ -543,7 +543,7 @@ tidyselect::where
 dplyr_mode <- FALSE
 
 on_load({
-  if (!identical(Sys.getenv("TESTTHAT"), "true") & is.null(getOption("duckdb.materialize_message"))) {
+  if (!identical(Sys.getenv("TESTTHAT"), "true") && is.null(getOption("duckdb.materialize_message"))) {
     options(duckdb.materialize_message = TRUE)
   }
 })


### PR DESCRIPTION
Hi,

If `options(duckdb.materialize_message = FALSE)` is specified in the `.Rprofile` file, it will be overridden by
```
on_load({
  if (!identical(Sys.getenv("TESTTHAT"), "true")) {
    options(duckdb.materialize_message = TRUE)
  }
})
```
when starting an `.Rproj`. I suggest checking if the option is already specified and maybe setting the default to `FALSE` as mentioned in #209. 

Thanks & all the best!