### PR TITLE
feat: `as_duckplyr_tibble()` supports dbplyr connections to a duckdb database

### DIFF
--- a/R/as_duckplyr_tibble.R
+++ b/R/as_duckplyr_tibble.R
@@ -8,6 +8,15 @@
 #' @rdname as_duckplyr_df
 #' @export
 as_duckplyr_tibble <- function(.data) {
+  if (inherits(.data, "tbl_duckdb_connection")) {
+    con <- dbplyr::remote_con(.data)
+    sql <- dbplyr::remote_query(.data)
+    rel <- duckdb$rel_from_sql(con, sql)
+    out <- rel_to_df(rel)
+    class(out) <- c("duckplyr_df", class(new_tibble(list())))
+    return(out)
+  }
+
   # Extra as.data.frame() call for good measure and perhaps https://github.com/tidyverse/tibble/issues/1556
   as_duckplyr_df(as_tibble(as.data.frame(.data)))
 }


### PR DESCRIPTION
Closes #86.
Closes #211.