### PR TITLE
feat: More complete `across()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,6 +26,7 @@ Imports:
     glue,
     jsonlite,
     lifecycle,
+    memoise,
     rlang (>= 1.0.6),
     tibble,
     tidyselect,

--- a/R/duckplyr-across.R
+++ b/R/duckplyr-across.R
@@ -61,10 +61,12 @@ duckplyr_expand_across <- function(data, quo) {
   # duckplyr doesn't currently support >1 function so we bail if we
   # see that potential case, but to potentially allow for this in the future we
   # manually wrap in a list using the default name of `"1"`.
-  if (!is.function(fns)) {
+  if (is.function(fns)) {
+    fns <- list("1" = fns)
+  }
+  if (length(fns) != 1) {
     return(NULL)
   }
-  fns <- list("1" = fns)
 
   # In dplyr this evaluates in the mask to reproduce the `mutate()` or
   # `summarise()` context. We don't have a mask here but it's probably fine in

--- a/R/duckplyr-across.R
+++ b/R/duckplyr-across.R
@@ -191,6 +191,12 @@ fn_to_expr <- function(fn, env) {
   out
 }
 
+# Memoize get_ns_exports_lookup() to avoid recomputing the hash of
+# every function in every namespace every time
+on_load({
+  get_ns_exports_lookup <<- memoise::memoise(get_ns_exports_lookup)
+})
+
 get_ns_exports_lookup <- function(ns) {
   names <- getNamespaceExports(ns)
   objs <- mget(names, ns)

--- a/R/duckplyr-across.R
+++ b/R/duckplyr-across.R
@@ -58,11 +58,6 @@ duckplyr_expand_across <- function(data, quo) {
   fns <- as_quosure(expr$.fns, env)
   fns <- quo_eval_fns(fns, mask = env, error_call = error_call)
 
-  # duckplyr doesn't currently support >1 function.
-  if (!is.function(fns) && length(fns) != 1) {
-    return(NULL)
-  }
-
   # In dplyr this evaluates in the mask to reproduce the `mutate()` or
   # `summarise()` context. We don't have a mask here but it's probably fine in
   # almost all cases.
@@ -126,8 +121,6 @@ duckplyr_across_setup <- function(data,
                                   names,
                                   .caller_env,
                                   error_call = caller_env()) {
-  stopifnot(is.function(fns) || length(fns) == 1)
-
   data <- set_names(seq_along(data), data)
 
   vars <- tidyselect::eval_select(
@@ -164,10 +157,9 @@ duckplyr_across_setup <- function(data,
     }
   }
 
-  glue_mask <- across_glue_mask(
-    .col = names_vars,
-    .fn = names_fns,
-    .caller_env = .caller_env
+  glue_mask <- across_glue_mask(.caller_env,
+    .col = rep(names_vars, each = length(fns)),
+    .fn  = rep(names_fns , length(vars))
   )
   names <- vec_as_names(
     glue(names, .envir = glue_mask),

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -23,3 +23,8 @@
     packageStartupMessage(msg)
   }
 }
+
+# Avoid R CMD check warning
+dummy <- function() {
+  memoise::memoise()
+}

--- a/tests/testthat/_snaps/duckplyr-across.md
+++ b/tests/testthat/_snaps/duckplyr-across.md
@@ -3,7 +3,7 @@
     Code
       test_duckplyr_expand_across(c("x", "y"), across(x:y, mean))
     Output
-      tibble(x = mean(x), y = mean(y))
+      tibble(x = base::mean(x), y = base::mean(y))
 
 ---
 
@@ -17,7 +17,7 @@
     Code
       test_duckplyr_expand_across(c("x", "y"), across(c(x_mean = x, y_mean = y), mean))
     Output
-      tibble(x_mean = mean(x), y_mean = mean(y))
+      tibble(x_mean = base::mean(x), y_mean = base::mean(y))
 
 ---
 
@@ -25,7 +25,7 @@
       test_duckplyr_expand_across(c("x", "y"), across(c(x_mean = x, y_mean = y), mean,
       .names = "{.col}_{.fn}"))
     Output
-      tibble(x_mean_1 = mean(x), y_mean_1 = mean(y))
+      tibble(x_mean_1 = base::mean(x), y_mean_1 = base::mean(y))
 
 ---
 
@@ -59,10 +59,7 @@
 ---
 
     Code
-      # Is this intended?
       test_duckplyr_expand_across(c("x", "y"), across(x:y, base::mean))
     Output
-      tibble(x = (function (x, ...) 
-      UseMethod("mean"))(x), y = (function (x, ...) 
-      UseMethod("mean"))(y))
+      tibble(x = base::mean(x), y = base::mean(y))
 

--- a/tests/testthat/_snaps/duckplyr-across.md
+++ b/tests/testthat/_snaps/duckplyr-across.md
@@ -77,3 +77,11 @@
     Output
       tibble(x_mean = base::mean(x), y_mean = base::mean(y))
 
+---
+
+    Code
+      test_duckplyr_expand_across(c("x", "y"), across(x:y, list(mean = mean, median = median)))
+    Output
+      tibble(x_mean = base::mean(x), x_median = stats::median(x), y_mean = base::mean(y), 
+          y_median = stats::median(y))
+

--- a/tests/testthat/_snaps/duckplyr-across.md
+++ b/tests/testthat/_snaps/duckplyr-across.md
@@ -63,3 +63,18 @@
     Output
       tibble(x = base::mean(x), y = base::mean(y))
 
+---
+
+    Code
+      test_duckplyr_expand_across(c("x", "y"), across(x:y, list(mean)))
+    Output
+      tibble(x = base::mean(x), y = base::mean(y))
+
+---
+
+    Code
+      # This isn't quite right yet
+      test_duckplyr_expand_across(c("x", "y"), across(x:y, list(mean = mean)))
+    Output
+      tibble(x = base::mean(x), y = base::mean(y))
+

--- a/tests/testthat/_snaps/duckplyr-across.md
+++ b/tests/testthat/_snaps/duckplyr-across.md
@@ -68,13 +68,12 @@
     Code
       test_duckplyr_expand_across(c("x", "y"), across(x:y, list(mean)))
     Output
-      tibble(x = base::mean(x), y = base::mean(y))
+      tibble(x_1 = base::mean(x), y_1 = base::mean(y))
 
 ---
 
     Code
-      # This isn't quite right yet
       test_duckplyr_expand_across(c("x", "y"), across(x:y, list(mean = mean)))
     Output
-      tibble(x = base::mean(x), y = base::mean(y))
+      tibble(x_mean = base::mean(x), y_mean = base::mean(y))
 

--- a/tests/testthat/_snaps/duckplyr-across.md
+++ b/tests/testthat/_snaps/duckplyr-across.md
@@ -56,3 +56,13 @@
     Output
       tibble(x = x * x, y = y * y)
 
+---
+
+    Code
+      # Is this intended?
+      test_duckplyr_expand_across(c("x", "y"), across(x:y, base::mean))
+    Output
+      tibble(x = (function (x, ...) 
+      UseMethod("mean"))(x), y = (function (x, ...) 
+      UseMethod("mean"))(y))
+

--- a/tests/testthat/test-duckplyr-across.R
+++ b/tests/testthat/test-duckplyr-across.R
@@ -54,6 +54,14 @@ test_that("duckplyr_expand_across() successful", {
       across(-a, function(x) x * x)
     )
   })
+
+  expect_snapshot({
+    "Is this intended?"
+    test_duckplyr_expand_across(
+      c("x", "y"),
+      across(x:y, base::mean)
+    )
+  })
 })
 
 test_that("duckplyr_expand_across() failing", {

--- a/tests/testthat/test-duckplyr-across.R
+++ b/tests/testthat/test-duckplyr-across.R
@@ -56,7 +56,6 @@ test_that("duckplyr_expand_across() successful", {
   })
 
   expect_snapshot({
-    "Is this intended?"
     test_duckplyr_expand_across(
       c("x", "y"),
       across(x:y, base::mean)

--- a/tests/testthat/test-duckplyr-across.R
+++ b/tests/testthat/test-duckplyr-across.R
@@ -61,6 +61,21 @@ test_that("duckplyr_expand_across() successful", {
       across(x:y, base::mean)
     )
   })
+
+  expect_snapshot({
+    test_duckplyr_expand_across(
+      c("x", "y"),
+      across(x:y, list(mean))
+    )
+  })
+
+  expect_snapshot({
+    "This isn't quite right yet"
+    test_duckplyr_expand_across(
+      c("x", "y"),
+      across(x:y, list(mean = mean))
+    )
+  })
 })
 
 test_that("duckplyr_expand_across() failing", {
@@ -71,14 +86,6 @@ test_that("duckplyr_expand_across() failing", {
   expect_null(test_duckplyr_expand_across(
     c("x", "y"),
     across(x:y, mean, na.rm = TRUE)
-  ))
-  expect_null(test_duckplyr_expand_across(
-    c("x", "y"),
-    across(x:y, list(mean))
-  ))
-  expect_null(test_duckplyr_expand_across(
-    c("x", "y"),
-    across(x:y, list(mean = mean))
   ))
   expect_null(test_duckplyr_expand_across(
     c("x", "y"),

--- a/tests/testthat/test-duckplyr-across.R
+++ b/tests/testthat/test-duckplyr-across.R
@@ -75,6 +75,13 @@ test_that("duckplyr_expand_across() successful", {
       across(x:y, list(mean = mean))
     )
   })
+
+  expect_snapshot({
+    test_duckplyr_expand_across(
+      c("x", "y"),
+      across(x:y, list(mean = mean, median = median))
+    )
+  })
 })
 
 test_that("duckplyr_expand_across() failing", {
@@ -85,9 +92,5 @@ test_that("duckplyr_expand_across() failing", {
   expect_null(test_duckplyr_expand_across(
     c("x", "y"),
     across(x:y, mean, na.rm = TRUE)
-  ))
-  expect_null(test_duckplyr_expand_across(
-    c("x", "y"),
-    across(x:y, list(mean = mean, median = median))
   ))
 })

--- a/tests/testthat/test-duckplyr-across.R
+++ b/tests/testthat/test-duckplyr-across.R
@@ -70,7 +70,6 @@ test_that("duckplyr_expand_across() successful", {
   })
 
   expect_snapshot({
-    "This isn't quite right yet"
     test_duckplyr_expand_across(
       c("x", "y"),
       across(x:y, list(mean = mean))


### PR DESCRIPTION
Follow-up to #296.

This removes the need to keep the expressions used in the call to `across()` for the case of package functions. Non-package functions cannot be translated with duckplyr anyway at this stage.

This passes all tests, scheduling for merge, appreciate a review anyway.