### PR TITLE
feat: `mutate()` constructs intermediate data frames for each new variable

### DIFF
--- a/R/mutate.R
+++ b/R/mutate.R
@@ -22,7 +22,7 @@ mutate.duckplyr_df <- function(.data, ..., .by = NULL, .keep = c("all", "used", 
 
       names_used <- character()
       names_new <- character()
-      names_out <- rel_names(rel)
+      current_data <- rel_to_df(rel)
 
       # FIXME: use fewer projections
       for (i in seq_along(dots)) {
@@ -30,7 +30,7 @@ mutate.duckplyr_df <- function(.data, ..., .by = NULL, .keep = c("all", "used", 
         name_dot <- names_dots[[i]]
 
         # Try expanding this `dot` if we see it is an `across()` call
-        expanded <- duckplyr_expand_across(names_out, dot)
+        expanded <- duckplyr_expand_across(names(current_data), dot)
 
         if (is.null(expanded)) {
           # Nothing we can expand, create a list with just the 1 expression to
@@ -47,7 +47,7 @@ mutate.duckplyr_df <- function(.data, ..., .by = NULL, .keep = c("all", "used", 
 
         # Set up `exprs` outside the loop. All expressions expanded from an
         # `across()` are evaluated together using the same projection.
-        exprs <- imap(set_names(names_out), relexpr_reference, rel = NULL)
+        exprs <- imap(set_names(names(current_data)), relexpr_reference, rel = NULL)
 
         for (j in seq_along(quos)) {
           quo <- quos[[j]]
@@ -55,17 +55,16 @@ mutate.duckplyr_df <- function(.data, ..., .by = NULL, .keep = c("all", "used", 
 
           names_new <- c(names_new, new)
 
-          new_pos <- match(new, names_out, nomatch = length(names_out) + 1L)
-          new_expr <- rel_translate(quo, names_data = names_out, alias = new, partition = by_names, need_window = TRUE)
+          new_pos <- match(new, names(current_data), nomatch = length(current_data) + j)
+          new_expr <- rel_translate(quo, names_data = names(current_data), alias = new, partition = by_names, need_window = TRUE)
           exprs[[new_pos]] <- new_expr
-
-          names_out[[new_pos]] <- new
 
           new_names_used <- intersect(attr(new_expr, "used"), names(.data))
           names_used <- c(names_used, setdiff(new_names_used, names_used))
         }
 
         rel <- rel_project(rel, unname(exprs))
+        current_data <- rel_to_df(rel)
       }
 
       if (length(by_names) > 0) {


### PR DESCRIPTION
For #270.

@toppyy: I believe this is the only instance of `rel_translate()` that gets called without `data` . This will simplify your PR. Appreciate your thoughts.