### PR TITLE
feat: Add support for `sub()` and `gsub()`

### DIFF
--- a/R/relational-duckdb.R
+++ b/R/relational-duckdb.R
@@ -37,6 +37,8 @@ duckplyr_macros <- c(
   # https://github.com/duckdb/duckdb/discussions/8599
   # "as.Date" = '(x) AS strptime(x, \'%Y-%m-%d\')',
 
+  "sub" = "(pattern, replacement, x) AS (regexp_replace(x, pattern, replacement))",
+  "gsub" = "(pattern, replacement, x) AS (regexp_replace(x, pattern, replacement, 'g'))",
   "grepl" = "(pattern, x) AS (CASE WHEN x IS NULL THEN FALSE ELSE regexp_matches(x, pattern) END)",
   "if_else" = "(test, yes, no) AS (CASE WHEN test IS NULL THEN NULL ELSE CASE WHEN test THEN yes ELSE no END END)",
   "|" = "(x, y) AS (x OR y)",

--- a/R/translate.R
+++ b/R/translate.R
@@ -47,6 +47,8 @@ rel_find_call <- function(fun, env) {
     # "^" = "base",
     "min" = "base",
     # "replace" = "base",
+    "sub" = "base",
+    "gsub" = "base",
     "grepl" = "base",
     # ":" = "base",
     # "as.character" = "base",

--- a/tests/testthat/test-as_duckplyr_df.R
+++ b/tests/testthat/test-as_duckplyr_df.R
@@ -1535,6 +1535,58 @@ test_that("as_duckplyr_df_impl() and mutate(c = NA_character_, d = grepl('.', c)
 })
 
 
+test_that("as_duckplyr_df_impl() and mutate(c = 'abbc', d = gsub('(b|c)', 'z' , c))", {
+  # Data
+  test_df <- data.frame(a = 1:6 + 0, b = 2, g = rep(1:3, 1:3))
+
+  # Run
+  pre <- test_df %>% as_duckplyr_df_impl() %>% mutate(c = 'abbc', d = gsub('(b|c)', 'z' , c))
+  post <- test_df %>% mutate(c = 'abbc', d = gsub('(b|c)', 'z' , c)) %>% as_duckplyr_df_impl()
+
+  # Compare
+  expect_identical(pre, post)
+})
+
+
+test_that("as_duckplyr_df_impl() and mutate(c = 'abbc', d = sub('(b|c)', 'z' , c))", {
+  # Data
+  test_df <- data.frame(a = 1:6 + 0, b = 2, g = rep(1:3, 1:3))
+
+  # Run
+  pre <- test_df %>% as_duckplyr_df_impl() %>% mutate(c = 'abbc', d = sub('(b|c)', 'z' , c))
+  post <- test_df %>% mutate(c = 'abbc', d = sub('(b|c)', 'z' , c)) %>% as_duckplyr_df_impl()
+
+  # Compare
+  expect_identical(pre, post)
+})
+
+
+test_that("as_duckplyr_df_impl() and mutate(c = NA_character_, d = gsub('.', '-' , c))", {
+  # Data
+  test_df <- data.frame(a = 1:6 + 0, b = 2, g = rep(1:3, 1:3))
+
+  # Run
+  pre <- test_df %>% as_duckplyr_df_impl() %>% mutate(c = NA_character_, d = gsub('.', '-' , c))
+  post <- test_df %>% mutate(c = NA_character_, d = gsub('.', '-' , c)) %>% as_duckplyr_df_impl()
+
+  # Compare
+  expect_identical(pre, post)
+})
+
+
+test_that("as_duckplyr_df_impl() and mutate(c = NA_character_, d = sub('.', '-' , c))", {
+  # Data
+  test_df <- data.frame(a = 1:6 + 0, b = 2, g = rep(1:3, 1:3))
+
+  # Run
+  pre <- test_df %>% as_duckplyr_df_impl() %>% mutate(c = NA_character_, d = sub('.', '-' , c))
+  post <- test_df %>% mutate(c = NA_character_, d = sub('.', '-' , c)) %>% as_duckplyr_df_impl()
+
+  # Compare
+  expect_identical(pre, post)
+})
+
+
 test_that("as_duckplyr_df_impl() and mutate(d = a %in% NA_real_)", {
   # Data
   test_df <- data.frame(a = 1:6 + 0, b = 2, g = rep(1:3, 1:3))

--- a/tools/00-funs.R
+++ b/tools/00-funs.R
@@ -807,6 +807,14 @@ test_extra_arg_map <- list(
     # grepl() with NA
     "c = NA_character_, d = grepl('.', c)",
 
+    # sub and gsub
+    "c = 'abbc', d = gsub('(b|c)', 'z' , c)",
+    "c = 'abbc', d = sub('(b|c)', 'z' , c)",
+
+    # sub and gsub with NA
+    "c = NA_character_, d = gsub('.', '-' , c)",
+    "c = NA_character_, d = sub('.', '-' , c)",
+
     # %in% with NA
     "d = a %in% NA_real_",
     # https://github.com/hannes/duckdb-rfuns/issues/89

--- a/vignettes/limits.Rmd
+++ b/vignettes/limits.Rmd
@@ -43,7 +43,7 @@ As of now, here are the translations provided:
 
 - Branching and conversion: `is.na()`, `dplyr::if_else()`, `as.integer()`, `strftime()`
 
-- String manipulation: `grepl()`, `substr()`
+- String manipulation: `grepl()`, `substr()`, `sub()`, `gsub()`
 
 - Date manipulation: `lubridate::hour()`, `lubridate::minute()`, `lubridate::second()`, `lubridate::wday()`
 


### PR DESCRIPTION
Adds translation for sub and gsub to regexp_replace. No related issue.

No support for parameters beyond pattern, replacement and x.