### PR TITLE
docs: Prefer `DUCKPLYR_FALLBACK_INFO` over `DUCKPLYR_FALLBACK_VERBOSE`

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -12,9 +12,6 @@
 #'
 #' `DUCKPLYR_FORCE`: If `TRUE`, fail if duckdb cannot handle a request.
 #'
-#' `DUCKPLYR_FALLBACK_INFO`: If `TRUE`, print a message when a fallback to dplyr occurs
-#' because DuckDB cannot handle a request.
-#'
 #' `DUCKPLYR_CHECK_ROUNDTRIP`: If `TRUE`, check if all columns are roundtripped perfectly
 #' when creating a relational object from a data frame,
 #' This is slow, and mostly useful for debugging.
@@ -27,7 +24,8 @@
 #' `DUCKPLYR_METHODS_OVERWRITE`: If `TRUE`, call `methods_overwrite()`
 #' when the package is loaded.
 #'
-#' See [fallback] for more options related to logging and uploading of fallback events.
+#' See [fallback] for more options related to printing, logging, and uploading
+#' of fallback events.
 #'
 # Not available in the CRAN package:
 # `DUCKPLYR_META_GLOBAL`: Assume data frames in the global environment as "known".

--- a/R/relational.R
+++ b/R/relational.R
@@ -39,7 +39,7 @@ rel_try <- function(call, rel, ...) {
         }
 
         if (Sys.getenv("DUCKPLYR_FALLBACK_INFO") == "TRUE") {
-          inform(message = c("Requested fallback for relational:", i = message))
+          inform(message = c("Cannot process duckplyr query with DuckDB, falling back to dplyr.", i = message))
         }
         if (Sys.getenv("DUCKPLYR_FORCE") == "TRUE") {
           cli::cli_abort("Fallback not available with {.envvar DUCKPLYR_FORCE}.")
@@ -59,7 +59,7 @@ rel_try <- function(call, rel, ...) {
     tel_collect(out, call)
 
     if (Sys.getenv("DUCKPLYR_FALLBACK_INFO") == "TRUE") {
-      rlang::cnd_signal(rlang::message_cnd(message = "Cannot process duckplyr query with DuckDB, falling back to dplyr.", parent = out))
+      rlang::cnd_signal(rlang::message_cnd(message = "Error processing duckplyr query with DuckDB, falling back to dplyr.", parent = out))
     }
     stats$fallback <- stats$fallback + 1L
     return()

--- a/man/config.Rd
+++ b/man/config.Rd
@@ -17,9 +17,6 @@ with less potential for optimization, and thus may be slower.
 
 \code{DUCKPLYR_FORCE}: If \code{TRUE}, fail if duckdb cannot handle a request.
 
-\code{DUCKPLYR_FALLBACK_INFO}: If \code{TRUE}, print a message when a fallback to dplyr occurs
-because DuckDB cannot handle a request.
-
 \code{DUCKPLYR_CHECK_ROUNDTRIP}: If \code{TRUE}, check if all columns are roundtripped perfectly
 when creating a relational object from a data frame,
 This is slow, and mostly useful for debugging.
@@ -32,7 +29,8 @@ Currently unused.
 \code{DUCKPLYR_METHODS_OVERWRITE}: If \code{TRUE}, call \code{methods_overwrite()}
 when the package is loaded.
 
-See \link{fallback} for more options related to logging and uploading of fallback events.
+See \link{fallback} for more options related to printing, logging, and uploading
+of fallback events.
 }
 
 \examples{

--- a/man/fallback.Rd
+++ b/man/fallback.Rd
@@ -29,9 +29,10 @@ With \code{FALSE}, only a message is printed.}
 \description{
 The \pkg{duckplyr} package aims at providing
 a fully compatible drop-in replacement for \pkg{dplyr}.
-To achieve this, only a carefully selected subset of dplyr's operations,
+To achieve this, only a carefully selected subset of \pkg{dplyr}'s operations,
 R functions, and R data types are implemented.
-Whenever duckplyr encounters an incompatibility, it falls back to dplyr.
+Whenever a request cannot be handled by DuckDB,
+\pkg{duckplyr} falls back to \pkg{dplyr}.
 
 To assist future development, the fallback situations can be logged
 to the console or to a local file and uploaded for analysis.
@@ -50,29 +51,28 @@ Only authorized personnel have access to the reports.
 \code{fallback_purge()} deletes some or all available reports.
 }
 \details{
-Logging and uploading are both opt-in.
-By default, for logging, a message is printed to the console
-for the first time in a session and then once every 8 hours.
+Logging is on by default, but can be turned off.
+Uploading is opt-in.
 
 The following environment variables control the logging and uploading:
 \itemize{
+\item \code{DUCKPLYR_FALLBACK_INFO} controls human-friendly alerts
+for fallback events.
+If \code{TRUE}, a message is printed when a fallback to dplyr occurs
+because DuckDB cannot handle a request.
+These messages are never logged.
 \item \code{DUCKPLYR_FALLBACK_COLLECT} controls logging, set it
 to 1 or greater to enable logging.
 If the value is 0, logging is disabled.
-Future versions of duckplyr may start logging additional data
+Future versions of \pkg{duckplyr} may start logging additional data
 and thus require a higher value to enable logging.
 Set to 99 to enable logging for all future versions.
 Use \code{\link[usethis:edit]{usethis::edit_r_environ()}} to edit the environment file.
-\item \code{DUCKPLYR_FALLBACK_VERBOSE} controls printing, set it
-to \code{TRUE} or \code{FALSE} to enable or disable printing.
-If the value is \code{TRUE}, a message is printed to the console
-for each fallback situation.
-This setting is only relevant if logging is enabled.
 \item \code{DUCKPLYR_FALLBACK_AUTOUPLOAD} controls uploading, set it
 to 1 or greater to enable uploading.
 If the value is 0, uploading is disabled.
 Currently, uploading is active if the value is 1 or greater.
-Future versions of duckplyr may start logging additional data
+Future versions of \pkg{duckplyr} may start logging additional data
 and thus require a higher value to enable uploading.
 Set to 99 to enable uploading for all future versions.
 Use \code{\link[usethis:edit]{usethis::edit_r_environ()}} to edit the environment file.
@@ -80,6 +80,12 @@ Use \code{\link[usethis:edit]{usethis::edit_r_environ()}} to edit the environmen
 It must point to a directory (existing or not) where the logs will be written.
 By default, logs are written to a directory in the user's cache directory
 as returned by \code{tools::R_user_dir("duckplyr", "cache")}.
+\item \code{DUCKPLYR_FALLBACK_VERBOSE} controls printing of log data, set it
+to \code{TRUE} or \code{FALSE} to enable or disable printing.
+If the value is \code{TRUE}, a message is printed to the console
+for each fallback situation.
+This setting is only relevant if logging is enabled,
+and mostly useful for \pkg{duckplyr}'s internal tests.
 }
 
 All code related to fallback logging and uploading is in the

--- a/tests/testthat/_snaps/fallback.md
+++ b/tests/testthat/_snaps/fallback.md
@@ -4,10 +4,10 @@
       fallback_sitrep()
     Message
       The duckplyr package is configured to fall back to dplyr when it encounters an incompatibility. Fallback events can be collected and uploaded for analysis to guide future development. By default, data will be collected but no data will be uploaded.
+      x Fallback printing is disabled.
       v Fallback logging is enabled.
       i Fallback logging is not controlled, see `?duckplyr::fallback()`.
       i Logs are written to 'fallback/log/dir'.
-      x Fallback printing is disabled.
       i Fallback uploading is not controlled and therefore disabled, see `?duckplyr::fallback()`.
       i No reports ready for upload.
       i See `?duckplyr::fallback()` for details.
@@ -18,9 +18,9 @@
       fallback_sitrep()
     Message
       The duckplyr package is configured to fall back to dplyr when it encounters an incompatibility. Fallback events can be collected and uploaded for analysis to guide future development. By default, data will be collected but no data will be uploaded.
+      x Fallback printing is disabled.
       v Fallback logging is enabled.
       i Logs are written to 'fallback/log/dir'.
-      x Fallback printing is disabled.
       v Fallback uploading is enabled.
       v Number of reports ready for upload: 3.
       > Review with `duckplyr::fallback_review()`, upload with `duckplyr::fallback_upload()`.
@@ -32,9 +32,9 @@
       fallback_sitrep()
     Message
       The duckplyr package is configured to fall back to dplyr when it encounters an incompatibility. Fallback events can be collected and uploaded for analysis to guide future development. By default, data will be collected but no data will be uploaded.
+      v Fallback printing is enabled.
       v Fallback logging is enabled.
       i Logs are written to 'fallback/log/dir'.
-      x Fallback printing is disabled.
       v Fallback uploading is enabled.
       v Number of reports ready for upload: 3.
       > Review with `duckplyr::fallback_review()`, upload with `duckplyr::fallback_upload()`.
@@ -46,6 +46,7 @@
       fallback_sitrep()
     Message
       The duckplyr package is configured to fall back to dplyr when it encounters an incompatibility. Fallback events can be collected and uploaded for analysis to guide future development. By default, data will be collected but no data will be uploaded.
+      x Fallback printing is disabled.
       x Fallback logging is disabled.
       x Fallback uploading is disabled.
       i See `?duckplyr::fallback()` for details.

--- a/tests/testthat/_snaps/relational.md
+++ b/tests/testthat/_snaps/relational.md
@@ -3,7 +3,7 @@
     Code
       rel_try(NULL, `Not affected` = FALSE, Affected = TRUE, { })
     Message
-      Requested fallback for relational:
+      Cannot process duckplyr query with DuckDB, falling back to dplyr.
       i Affected
     Output
       NULL

--- a/tests/testthat/test-fallback.R
+++ b/tests/testthat/test-fallback.R
@@ -1,7 +1,7 @@
 test_that("fallback_sitrep() default", {
   withr::local_envvar(c(
     "DUCKPLYR_FALLBACK_COLLECT" = "",
-    "DUCKPLYR_FALLBACK_VERBOSE" = "",
+    "DUCKPLYR_FALLBACK_INFO" = "",
     "DUCKPLYR_FALLBACK_AUTOUPLOAD" = "",
     "DUCKPLYR_FALLBACK_LOG_DIR" = "fallback/log/dir",
     "DUCKPLYR_TELEMETRY_FALLBACK_LOGS" = ""
@@ -15,7 +15,7 @@ test_that("fallback_sitrep() default", {
 test_that("fallback_sitrep() enabled", {
   withr::local_envvar(c(
     "DUCKPLYR_FALLBACK_COLLECT" = "1",
-    "DUCKPLYR_FALLBACK_VERBOSE" = "",
+    "DUCKPLYR_FALLBACK_INFO" = "",
     "DUCKPLYR_FALLBACK_AUTOUPLOAD" = "1",
     "DUCKPLYR_FALLBACK_LOG_DIR" = "fallback/log/dir",
     "DUCKPLYR_TELEMETRY_FALLBACK_LOGS" = "1,2,3"
@@ -29,7 +29,7 @@ test_that("fallback_sitrep() enabled", {
 test_that("fallback_sitrep() enabled silent", {
   withr::local_envvar(c(
     "DUCKPLYR_FALLBACK_COLLECT" = "1",
-    "DUCKPLYR_FALLBACK_VERBOSE" = "FALSE",
+    "DUCKPLYR_FALLBACK_INFO" = "TRUE",
     "DUCKPLYR_FALLBACK_AUTOUPLOAD" = "1",
     "DUCKPLYR_FALLBACK_LOG_DIR" = "fallback/log/dir",
     "DUCKPLYR_TELEMETRY_FALLBACK_LOGS" = "1,2,3"


### PR DESCRIPTION
For #216.