### PR TITLE
feat: The default DuckDB connection is now based on a file, the location can be controlled with the `DUCKPLYR_TEMP_DIR` environment variable

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -5,6 +5,9 @@
 #'
 #' @section Environment variables:
 #'
+#' `DUCKPLYR_TEMP_DIR`: Set to a path where temporary files can be created.
+#' By default, [tempdir()] is used.
+#'
 #' `DUCKPLYR_OUTPUT_ORDER`: If `TRUE`, row output order is preserved.
 #' The default may change the row order where dplyr would keep it stable.
 #' Preserving the order leads to more complicated execution plans

--- a/R/relational-duckdb.R
+++ b/R/relational-duckdb.R
@@ -59,11 +59,13 @@ duckplyr_macros <- c(
 )
 
 create_default_duckdb_connection <- function() {
-  drv <- duckdb::duckdb()
+  dbroot <- Sys.getenv("DUCKPLYR_TEMP_DIR", tempdir())
+  dbdir <- tempfile("duckplyr", tmpdir = dbroot, fileext = ".duckdb")
+
+  drv <- duckdb::duckdb(dbdir = dbdir)
   con <- DBI::dbConnect(drv)
 
-  # DBI::dbExecute(con, "set memory_limit='1GB'")
-  DBI::dbExecute(con, paste0("pragma temp_directory='", tempdir(), "'"))
+  DBI::dbExecute(con, paste0("pragma temp_directory='", dbroot, "'"))
 
   duckdb$rapi_load_rfuns(drv@database_ref)
 

--- a/man/config.Rd
+++ b/man/config.Rd
@@ -10,6 +10,9 @@ and one option.
 \section{Environment variables}{
 
 
+\code{DUCKPLYR_TEMP_DIR}: Set to a path where temporary files can be created.
+By default, \code{\link[=tempdir]{tempdir()}} is used.
+
 \code{DUCKPLYR_OUTPUT_ORDER}: If \code{TRUE}, row output order is preserved.
 The default may change the row order where dplyr would keep it stable.
 Preserving the order leads to more complicated execution plans


### PR DESCRIPTION
Closes #439.