### PR TITLE
chore: Clean up source in error

### DIFF
--- a/R/ducktbl.R
+++ b/R/ducktbl.R
@@ -93,19 +93,18 @@ duckdb_tibble <- function(..., .lazy = FALSE) {
 #' @rdname duckdb_tibble
 #' @export
 as_duckdb_tibble <- function(x, ..., .lazy = FALSE) {
-  out <- as_duckdb_tibble_dispatch(x, ...)
-
-  if (isTRUE(.lazy)) {
-    out <- as_lazy_duckplyr_df(out)
-  } else {
-    out <- as_eager_duckplyr_df(out)
+  # Handle the .lazy arg in the generic, only the other args will be dispatched
+  as_duckdb_tibble <- function(x, ...) {
+    UseMethod("as_duckdb_tibble")
   }
 
-  return(out)
-  UseMethod("as_duckdb_tibble")
-}
-as_duckdb_tibble_dispatch <- function(x, ...) {
-  UseMethod("as_duckdb_tibble")
+  out <- as_duckdb_tibble(x, ...)
+
+  if (isTRUE(.lazy)) {
+    as_lazy_duckplyr_df(out)
+  } else {
+    as_eager_duckplyr_df(out)
+  }
 }
 
 #' @export

--- a/tests/testthat/_snaps/ducktbl.md
+++ b/tests/testthat/_snaps/ducktbl.md
@@ -3,7 +3,7 @@
     Code
       as_duckdb_tibble(dplyr::group_by(mtcars, cyl))
     Condition
-      Error in `as_duckdb_tibble_dispatch()`:
+      Error in `as_duckdb_tibble()`:
       ! duckplyr does not support `group_by()`.
       i Use `.by` instead.
       i To proceed with dplyr, use `as_tibble()` or `as.data.frame()`.
@@ -13,7 +13,7 @@
     Code
       as_duckdb_tibble(dplyr::rowwise(mtcars))
     Condition
-      Error in `as_duckdb_tibble_dispatch()`:
+      Error in `as_duckdb_tibble()`:
       ! duckplyr does not support `rowwise()`.
       i To proceed with dplyr, use `as_tibble()` or `as.data.frame()`.
 


### PR DESCRIPTION
@lionel- @DavisVaughan @hadley: I'm trying out this pattern for getting a clean source of error, see the snapshot diff at https://github.com/tidyverse/duckplyr/pull/468/files#diff-e6f6630cd5973ffe606db6f51980c092691e89bd56970e58edf3f03711aab6e7R6 . Is there a cleaner way to achieve this?