### PR TITLE
fix: Remove startup message after second `load_all()`

### DIFF
--- a/R/fallback.R
+++ b/R/fallback.R
@@ -300,7 +300,12 @@ fallback_config_load <- function() {
 }
 
 fallback_config_reset <- function(config, name, envvar) {
-  if (!is.na(Sys.getenv(envvar, unset = NA))) {
+  if (is.null(config[[name]])) {
+    return(config)
+  }
+
+  val <- Sys.getenv(envvar, unset = NA)
+  if (!is.na(val) && !identical(val, config[[name]])) {
     config[[name]] <- NULL
   }
   config

--- a/tests/testthat/_snaps/fallback.md
+++ b/tests/testthat/_snaps/fallback.md
@@ -226,20 +226,13 @@
 # fallback_config()
 
     Code
+      # No conflicts
       fallback_config_load()
-    Message
-      Some configuration values are set as environment variables and in the configuration file 'fallback.dcf':
-      * `info`
-      * `logging`
-      * `autoupload`
-      * `log_dir`
-      * `verbose`
-      i Use `duckplyr::fallback_config(reset_all = TRUE)` to reset the configuration.
-      i Use `usethis::edit_r_environ()` to edit '~/.Renviron'.
 
 ---
 
     Code
+      # Reset and set config
       fallback_config(reset_all = TRUE, logging = FALSE)
     Message
       i Restart the R session to reset all values to their defaults.
@@ -247,6 +240,7 @@
 ---
 
     Code
+      # Conflicts with environment variable and setting
       fallback_config_load()
     Message
       Some configuration values are set as environment variables and in the configuration file 'fallback.dcf':
@@ -257,6 +251,7 @@
 ---
 
     Code
+      # Reset config
       fallback_config(reset_all = TRUE)
     Message
       i Restart the R session to reset all values to their defaults.

--- a/tests/testthat/test-fallback.R
+++ b/tests/testthat/test-fallback.R
@@ -226,6 +226,7 @@ test_that("fallback_config()", {
   withr::local_envvar(c(
     "DUCKPLYR_FALLBACK_COLLECT" = NA_character_,
     "DUCKPLYR_FALLBACK_INFO" = NA_character_,
+    "DUCKPLYR_FALLBACK_LOGGING" = NA_character_,
     "DUCKPLYR_FALLBACK_AUTOUPLOAD" = NA_character_,
     "DUCKPLYR_FALLBACK_LOG_DIR" = NA_character_,
     "DUCKPLYR_FALLBACK_VERBOSE" = NA_character_
@@ -240,19 +241,26 @@ test_that("fallback_config()", {
   expect_snapshot_file(config_path, "fallback.dcf")
 
   expect_snapshot({
+    "No conflicts"
     fallback_config_load()
   })
 
   expect_snapshot({
+    "Reset and set config"
     fallback_config(reset_all = TRUE, logging = FALSE)
   })
   expect_snapshot_file(config_path, "fallback-2.dcf")
 
+  withr::local_envvar(c(
+    DUCKPLYR_FALLBACK_LOGGING = 1
+  ))
   expect_snapshot({
+    "Conflicts with environment variable and setting"
     fallback_config_load()
   })
 
   expect_snapshot({
+    "Reset config"
     fallback_config(reset_all = TRUE)
   })
   expect_false(file.exists(config_path))


### PR DESCRIPTION
Closes #480.