### PR TITLE
fledge: CRAN release v1.0.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: duckplyr
 Title: A 'DuckDB'-Backed Version of 'dplyr'
-Version: 1.0.0.9004
+Version: 1.0.1
 Authors@R: c(
     person("Hannes", "Mühleisen", role = "aut",
            comment = c(ORCID = "0000-0001-8552-0029")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@
 
 - Require duckdb \>= 1.2.0 (#619).
 
-- Break this version with the release of duckdb 2.0.0 (#623).
+- Break this version with duckdb 2.0.0 (#623).
 
 ## Documentation
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,14 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# duckplyr 1.0.0.9004 (2025-02-21)
+# duckplyr 1.0.1 (2025-02-21)
 
 ## Bug fixes
 
 - Check if extensions can be loaded before running examples and vignettes (#620).
+
+- Show source of error if data frame cannot be converted to duck frame (#614).
+
+- Fix link in documentation (#600, #601).
 
 ## Features
 
@@ -22,31 +26,7 @@
 
 - Italicize book title in README (@wibeasley, #607).
 
-
-# duckplyr 1.0.0.9003 (2025-02-21)
-
-## Documentation
-
 - Fix typo in `filter(.by = ...)` error message (#611).
-
-
-# duckplyr 1.0.0.9002 (2025-02-15)
-
-## Bug fixes
-
-- Show source of error if data frame cannot be converted to duck frame (#614).
-
-
-# duckplyr 1.0.0.9001 (2025-02-12)
-
-## Bug fixes
-
-- Fix link in documentation (#600, #601).
-
-
-# duckplyr 1.0.0.9000 (2025-02-08)
-
-## Documentation
 
 - Use stingy instead of frugal (#594).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,27 +8,21 @@
 
 - Show source of error if data frame cannot be converted to duck frame (#614).
 
-- Fix link in documentation (#600, #601).
-
-## Features
-
-- Break this version with the release of duckdb 2.0.0 (#623).
-
 ## Chore
 
 - Require duckdb \>= 1.2.0 (#619).
+
+- Break this version with the release of duckdb 2.0.0 (#623).
 
 ## Documentation
 
 - Separate `?compute_parquet` and `?compute_csv` (#610, #622).
 
-- Re-render README.
-
 - Italicize book title in README (@wibeasley, #607).
 
-- Fix typo in `filter(.by = ...)` error message (#611).
+- Fix typo in `filter(.by = ...)` error message (@maelle, #611).
 
-- Use stingy instead of frugal (#594).
+- Fix link in documentation (#600, #601).
 
 
 # duckplyr 1.0.0 (2025-02-02)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-duckplyr 1.0.0
+duckplyr 1.0.1
 
 ## Cran Repository Policy
 


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2025-02-21, problems found: https://cran.r-project.org/web/checks/check_results_duckplyr.html
- [x] ERROR: r-devel-linux-x86_64-fedora-clang
     Running examples in ‘duckplyr-Ex.R’ failed
     The error most likely occurred in:
     
     > ### Name: read_file_duckdb
     > ### Title: Read Parquet, CSV, and other files using DuckDB
     > ### Aliases: read_file_duckdb read_parquet_duckdb read_csv_duckdb
     > ###   read_json_duckdb
     > 
     > ### ** Examples
     > 
     > # Create simple CSV file
     > path <- tempfile("duckplyr_test_", fileext = ".csv")
     > write.csv(data.frame(a = 1:3, b = letters[4:6]), path, row.names = FALSE)
     > 
     > # Reading is immediate
     > df <- read_csv_duckdb(path)
     > 
     > # Names are always available
     > names(df)
     [1] "a" "b"
     > 
     > # Materialization upon access is turned off by default
     > try(print(df$a))
     [1] 1 2 3
     > 
     > # Materialize explicitly
     > collect(df)$a
     [1] 1 2 3
     > 
     > # Automatic materialization with prudence = "lavish"
     > df <- read_csv_duckdb(path, prudence = "lavish")
     > df$a
     [1] 1 2 3
     > 
     > # Specify column types
     > read_csv_duckdb(
     +   path,
     +   options = list(delim = ",", types = list(c("DOUBLE", "VARCHAR")))
     + )
     # A duckplyr data frame: 2 variables
     a b    
     <dbl> <chr>
     1     1 d    
     2     2 e    
     3     3 f    
     > 
     > # Create and read a simple JSON file
     > path <- tempfile("duckplyr_test_", fileext = ".json")
     > writeLines('[{"a": 1, "b": "x"}, {"a": 2, "b": "y"}]', path)
     > 
     > # Reading needs the json extension
     > db_exec("INSTALL json")
     > db_exec("LOAD json")
     
     *** caught segfault ***
     address (nil), cause 'unknown'
     
     Traceback:
     1: rapi_execute(stmt, arrow, integer64)
     2: withCallingHandlers(expr, condition = function(cnd) {    {        .__handler_frame__. <- TRUE        .__setup_frame__. <- frame        if (inherits(cnd, "message")) {            except <- c("warning", "error")        }        else if (inherits(cnd, "warning")) {            exce
- [x] ERROR: r-devel-linux-x86_64-fedora-clang
     Error(s) in re-building vignettes:
     --- re-building ‘developers.Rmd’ using rmarkdown
     --- finished re-building ‘developers.Rmd’
     
     --- re-building ‘extend.Rmd’ using rmarkdown
     --- finished re-building ‘extend.Rmd’
     
     --- re-building ‘fallback.Rmd’ using rmarkdown
     --- finished re-building ‘fallback.Rmd’
     
     --- re-building ‘large.Rmd’ using rmarkdown
     
     Quitting from lines 168-170 [unnamed-chunk-10] (large.Rmd)
     Error: processing vignette 'large.Rmd' failed with diagnostics:
     rapi_execute: Failed to run query
     Error: Invalid Input Error: Initialization function "httpfs_init" from file "/data/gannet/ripley/.local/share/R/duckdb/extensions/v1.2.0/linux_amd64_gcc4/httpfs.duckdb_extension" threw an exception: "Attempted to dereference unique_ptr that is NULL!"
     --- failed re-building ‘large.Rmd’
     
     --- re-building ‘limits.Rmd’ using rmarkdown
     --- finished re-building ‘limits.Rmd’
     
     --- re-building ‘prudence.Rmd’ using rmarkdown
     --- finished re-building ‘prudence.Rmd’
     
     --- re-building ‘telemetry.Rmd’ using rmarkdown
     --- finished re-building ‘telemetry.Rmd’
     
     SUMMARY: processing the following file failed:
     ‘large.Rmd’
     
     Error: Vignette re-building failed.
     Execution halted

Check results at: https://cran.r-project.org/web/checks/check_results_duckplyr.html

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`