### PR TITLE
Don't overwrite methods on attach if DUCKPLYR_METHODS_OVERWRITE == "FALSE"

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -20,7 +20,7 @@
 #' This is slow, and mostly useful for debugging.
 #' The default is to check roundtrip of attributes.
 #'
-#' `DUCKPLYR_METHODS_OVERWRITE`: If `TRUE`, call `methods_overwrite()`
+#' `DUCKPLYR_METHODS_OVERWRITE`: If `FALSE`, does not call `methods_overwrite()`
 #' when the package is loaded.
 #'
 #' See [fallback] for more options related to printing, logging, and uploading

--- a/R/config.R
+++ b/R/config.R
@@ -20,7 +20,7 @@
 #' This is slow, and mostly useful for debugging.
 #' The default is to check roundtrip of attributes.
 #'
-#' `DUCKPLYR_METHODS_OVERWRITE`: If `FALSE`, does not call `methods_overwrite()`
+#' `DUCKPLYR_METHODS_OVERWRITE`: If `FALSE`, do not call `methods_overwrite()`
 #' when the package is loaded.
 #'
 #' See [fallback] for more options related to printing, logging, and uploading

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -16,7 +16,7 @@ on_load({
 }
 
 .onAttach <- function(lib, pkg) {
-  if (!exists(".__DEVTOOLS__", asNamespace("duckplyr"))) {
+  if (!exists(".__DEVTOOLS__", asNamespace("duckplyr")) & Sys.getenv("DUCKPLYR_METHODS_OVERWRITE") != "FALSE") {
     msg <- character()
     suppressMessages(try_fetch(methods_overwrite(), message = function(cond) {
       msg <<- c(msg, conditionMessage(cond))


### PR DESCRIPTION
Solves https://github.com/tidyverse/duckplyr/issues/949. Since overwrite on attach seems to be the expected default behaviour, the check on DUCKPLYR_METHODS_OVERWRITE is wether it is false. The documentation in config has been updated to reflect this as well.